### PR TITLE
修复：兼容实体放置 NBT 列表映射

### DIFF
--- a/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
+++ b/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
@@ -728,8 +728,8 @@ public final class QuickCraftEntityPlacementServer {
     }
 
     private static boolean isListOf(ListTag list, int type) {
-        for (int i = 0; i < list.size(); i++) {
-            if (list.get(i).getId() != type) return false;
+        for (Tag element : list) {
+            if (element.getId() != type) return false;
         }
         return true;
     }


### PR DESCRIPTION
## 问题

QuickCraft 实体放置服务端协议使用 `ListTag#get(int)` 校验 NBT 列表元素类型。Minecraft 1.21.6–1.21.8 构建线的 FGA 包在 Yarn 1.21.8 开发环境中被处理为不存在的 `NbtList.get(int): NbtElement` 调用，实体放置请求进入 NBT 校验后抛出 `NoSuchMethodError`。

## 修复

改用增强 `for` 通过 `Iterable` 遍历列表，避免直接链接这个映射不稳定的方法。元素类型校验逻辑不变。

## 影响范围核对

已直接检查各开发运行环境处理后的旧包字节码：

- 1.21.5：保留 `NbtList.method_10534(int)`，运行时存在，不受影响
- 1.21.6–1.21.8：已在 1.21.8 实际复现 `NbtList.get(int): NbtElement` 链接失败
- 1.21.9–1.21.10：保留 `NbtList.method_10534(int)`，不受影响
- 1.21.11：保留 `NbtList.method_10534(int)`，不受影响
- 26.1.2/26.2：官方命名类存在 `ListTag.get(int): Tag`，不受影响

如需补发版本资产，只需替换 Minecraft 1.21.6–1.21.8 构建线。共享源码采用增强 `for` 后仍可安全构建其他版本，但这些版本无需重新发布。

## 验证

```text
./gradlew.bat :1.21.5:build :1.21.8:build :1.21.10:build :1.21.11:build :26.1.2:build :26.2:build
BUILD SUCCESSFUL
```