### PR TITLE
fix: 规则关闭时保留原版 Hopper 掉落物吸取链路

### DIFF
--- a/src/main/java/carpet/fga/mixin/HopperBlockEntityMixin.java
+++ b/src/main/java/carpet/fga/mixin/HopperBlockEntityMixin.java
@@ -2,6 +2,7 @@
 package carpet.fga.mixin;
 
 import carpet.fga.FGACompat;
+import carpet.fga.FGASettings;
 import net.minecraft.core.Direction;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -21,6 +22,9 @@ public abstract class HopperBlockEntityMixin {
     )
     private static void carpetFga$insertOversizedItemEntity(Container destination, ItemEntity itemEntity,
                                                              CallbackInfoReturnable<Boolean> cir) {
+        if (!FGASettings.isDroppedItemStackLimitEnabled()) {
+            return;
+        }
         ItemStack original = itemEntity.getItem();
         int batchLimit = Math.min(original.getMaxStackSize(),
                 //#if MC >= 1.20.5


### PR DESCRIPTION
## 主要变更

- 在 HopperBlockEntityMixin 的 ItemEntity → Hopper/HopperMinecart HEAD 注入入口增加 droppedItemStackLimit 规则门控。
- 规则关闭时直接退出注入，不读取或修改 ItemStack、不设置回调结果、不 cancel 原版方法；规则开启时保留原有批次循环和吞吐行为。

## 涉及范围

- 仅修改 src/main/java/carpet/fga/mixin/HopperBlockEntityMixin.java。
- 影响服务端 Hopper/ItemEntity 搬运路径，不涉及 Payload、网络协议、客户端 Mixin、客户端状态同步、配置格式、存档数据、规则默认值或权限；客户端无需安装 FGA。
- 覆盖构建节点：1.21.1、1.21.3、1.21.4、1.21.5、1.21.8、1.21.10、1.21.11、26.1.2、26.2。

## 验证

- git diff --check：通过。
- 九个节点的 compileJava：全部通过。
- Minecraft 1.21.1 临时专用服务器，Carpet Org Addition 1.41.6（carpet-org-addition-mc1.21.1-v1.41.6-2606231433.jar）：
  - shulkerBoxStackable=true、droppedItemStackLimit=false：地面 6 个潜影盒经漏斗矿车一次吸取后剩 5，目标仅增加 1；方块漏斗同样为 source -1 / target +1。
  - 不重启服务器，先开启 droppedItemStackLimit 得到目标五槽各 1、地面剩 1；直接关闭后，下一次场景立即恢复为目标仅 1、地面剩 5。
  - droppedItemStackLimit 开启时，200 stone 一次搬运结果为 64/64/64/8，地面实体清除。
  - 箱子 6 个潜影盒 → 漏斗矿车为 source 5 / target 1；该项仅作为独立回归，不作为 ItemEntity 根因证明。
  - 普通 6 stone ItemEntity 对漏斗矿车和方块漏斗均完整转移到目标，无残留；该项仅为普通回归。
- 日志按 debug.log、latest.log、crash-reports 顺序检查：成功运行无 Mixin 注入失败、异常、错误 cancel 或物品复制/丢失告警；仅有既有 Carpet 旧规则 API 警告和临时离线服务器警告，crash-reports 为空。

## 注意事项

- 运行时验收未新增复杂 Smoke 脚本；临时开发实例额外加载了 Org Addition 自带的 MixinExtras 0.5.0，以覆盖项目 1.21.1 开发运行时的 0.3.5。
- 现有规则描述与命令文档的不一致仅记录为后续事项，本 PR 不修改文档。