### PR TITLE
适配：QuickCraft 实体放置材料、乘客补放与铜傀儡返还

### DIFF
--- a/src/main/java/carpet/fga/CarpetFGAAddition.java
+++ b/src/main/java/carpet/fga/CarpetFGAAddition.java
@@ -36,6 +36,14 @@ public class CarpetFGAAddition implements ModInitializer {
                 QuickLitematicaEntityPlacementPayloads.RequestPayload.CODEC
         );
         //#if MC >= 26.1.2
+        //$$ PayloadTypeRegistry.serverboundPlay().register(
+        //#else
+        PayloadTypeRegistry.playC2S().register(
+        //#endif
+                QuickLitematicaEntityPlacementPayloads.PassengerRequestPayload.ID,
+                QuickLitematicaEntityPlacementPayloads.PassengerRequestPayload.CODEC
+        );
+        //#if MC >= 26.1.2
         //$$ PayloadTypeRegistry.clientboundPlay().register(
         //#else
         PayloadTypeRegistry.playS2C().register(
@@ -60,6 +68,11 @@ public class CarpetFGAAddition implements ModInitializer {
                 QuickLitematicaEntityPlacementPayloads.RequestPayload.ID,
                 (payload, context) -> context.server().execute(
                         () -> QuickCraftEntityPlacementServer.handleRequest(context.player(), payload))
+        );
+        ServerPlayNetworking.registerGlobalReceiver(
+                QuickLitematicaEntityPlacementPayloads.PassengerRequestPayload.ID,
+                (payload, context) -> context.server().execute(
+                        () -> QuickCraftEntityPlacementServer.handlePassengerRequest(context.player(), payload))
         );
         //#endif
         CarpetServer.manageExtension(new FGAExtension());

--- a/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
+++ b/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
@@ -191,6 +191,7 @@ public final class QuickCraftEntityPlacementServer {
             sendResult(player, payload.nonce(), "INTERNAL_ERROR", "");
             return;
         }
+        giveCopperChests(player, requested);
         sendResult(player, payload.nonce(), "SUCCESS", root.getUUID().toString());
     }
 
@@ -450,8 +451,6 @@ public final class QuickCraftEntityPlacementServer {
             if (copperBlock == null) return false;
             materials.add(new ItemStack(copperBlock));
             materials.add(new ItemStack(constructionPumpkin(player)));
-            Item copperChest = itemForId("minecraft", "copper_chest");
-            if (copperChest != null) materials.add(new ItemStack(copperChest));
             return true;
         }
         case "wither" -> {
@@ -484,6 +483,26 @@ public final class QuickCraftEntityPlacementServer {
                 : hasInventoryItem(player, Items.SOUL_SOIL)
                 ? Items.SOUL_SOIL
                 : Items.SOUL_SAND;
+    }
+
+    private static void giveCopperChests(ServerPlayer player, CompoundTag root) {
+        Item copperChest = itemForId("minecraft", "copper_chest");
+        if (copperChest == null) return;
+        int count = countEntities(root, "copper_golem");
+        for (int index = 0; index < count; index++) {
+            ItemStack stack = new ItemStack(copperChest);
+            if (!FGACompat.inventory(player).add(stack) && !stack.isEmpty()) player.drop(stack, false);
+        }
+    }
+
+    private static int countEntities(CompoundTag nbt, String path) {
+        String id = readEntityId(nbt);
+        int count = path.equals(id == null ? "" : pathOf(id)) ? 1 : 0;
+        ListTag passengers = listValue(nbt, "Passengers");
+        for (int index = 0; index < passengers.size(); index++) {
+            count += countEntities(compoundAt(passengers, index), path);
+        }
+        return count;
     }
 
     private static boolean appendStoredItem(

--- a/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
+++ b/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
@@ -73,35 +73,14 @@ public final class QuickCraftEntityPlacementServer {
                 session.enabled,
                 reach,
                 Math.min(MAX_ENTITY_NBT_BYTES, Math.max(0, payload.maxNbtBytes())),
-                0,
+                payload.features() & QuickLitematicaEntityPlacementPayloads.SERVER_FEATURES,
                 token
         ));
     }
 
     public static void handleRequest(ServerPlayer player, QuickLitematicaEntityPlacementPayloads.RequestPayload payload) {
         if (player == null || payload == null) return;
-        Session session = SESSIONS.get(player.getUUID());
-        if (session == null || !session.token.equals(payload.sessionToken())) {
-            sendResult(player, payload.nonce(), "DISABLED", "");
-            return;
-        }
-        long tick = player.serverLevel().getGameTime();
-        if (!session.enabled || !FGASettings.quickCraftEasyPlaceEntities) {
-            sendResult(player, payload.nonce(), "DISABLED", "");
-            return;
-        }
-        if (session.nonces.contains(payload.nonce())) {
-            sendResult(player, payload.nonce(), "REPLAYED_REQUEST", "");
-            return;
-        }
-        if (session.nonces.size() >= MAX_NONCES) session.nonces.removeFirst();
-        session.nonces.add(payload.nonce());
-        if (session.lastRequestTick != Long.MIN_VALUE
-                && tick - session.lastRequestTick < REQUEST_COOLDOWN_TICKS) {
-            sendResult(player, payload.nonce(), "RATE_LIMITED", "");
-            return;
-        }
-        session.lastRequestTick = tick;
+        if (!beginRequest(player, payload.sessionToken(), payload.nonce())) return;
 
         ServerLevel level = player.serverLevel();
         if (!dimensionId(level).equals(payload.dimension().toString())) {
@@ -195,13 +174,170 @@ public final class QuickCraftEntityPlacementServer {
         sendResult(player, payload.nonce(), "SUCCESS", root.getUUID().toString());
     }
 
+    public static void handlePassengerRequest(
+            ServerPlayer player,
+            QuickLitematicaEntityPlacementPayloads.PassengerRequestPayload payload
+    ) {
+        if (player == null || payload == null
+                || !beginRequest(player, payload.sessionToken(), payload.nonce())) return;
+        ServerLevel level = player.serverLevel();
+        if (!dimensionId(level).equals(payload.dimension().toString())) {
+            sendResult(player, payload.nonce(), "OUT_OF_REACH", "");
+            return;
+        }
+        Entity vehicle = level.getEntity(payload.vehicleUuid());
+        double reach = placementReach(player);
+        if (vehicle == null || !vehicle.isAlive()
+                || player.getEyePosition().distanceToSqr(vehicle.position()) > reach * reach) {
+            sendResult(player, payload.nonce(), "TARGET_ENTITY_MISSING", "");
+            return;
+        }
+        BlockPos targetPos = vehicle.blockPosition();
+        if (!level.hasChunkAt(targetPos)) {
+            sendResult(player, payload.nonce(), "WORLD_RULE_BLOCKED", "");
+            return;
+        }
+        if (!level.mayInteract(player, targetPos)) {
+            sendResult(player, payload.nonce(), "PERMISSION_DENIED", "");
+            return;
+        }
+        if (!vehicle.getPassengers().isEmpty()) {
+            sendResult(player, payload.nonce(), "PASSENGERS_PRESENT", "");
+            return;
+        }
+
+        CompoundTag requested = payload.entityNbt();
+        int[] entityCount = {0};
+        if (requested == null || requested.sizeInBytes() > MAX_ENTITY_NBT_BYTES
+                || !BuiltInRegistries.ENTITY_TYPE.getKey(vehicle.getType()).toString().equals(readEntityId(requested))
+                || !validateEntityTree(requested, 0, entityCount)) {
+            sendResult(player, payload.nonce(), "INVALID_NBT", "");
+            return;
+        }
+        ListTag passengerNbt = listValue(requested, "Passengers");
+        if (passengerNbt.isEmpty()) {
+            sendResult(player, payload.nonce(), "INVALID_NBT", "");
+            return;
+        }
+        List<ItemStack> required = materialsForPassengers(requested, level, player);
+        if (required == null) {
+            sendResult(player, payload.nonce(), "UNSUPPORTED_ENTITY", "");
+            return;
+        }
+        boolean creativeMaterialBypass = payload.creativeMaterialBypass() && player.isCreative();
+        if (!creativeMaterialBypass && !hasMaterials(player, required)) {
+            sendResult(player, payload.nonce(), "NO_MATERIAL", "");
+            return;
+        }
+
+        List<Entity> passengers = new ArrayList<>();
+        try {
+            for (int index = 0; index < passengerNbt.size(); index++) {
+                CompoundTag passenger = compoundAt(passengerNbt, index);
+                Entity entity = createEntityTree(level, passenger, vehicle.position(),
+                        0.0F, 0.0F, Vec3.ZERO, false, 1);
+                if (entity == null) {
+                    passengers.forEach(QuickCraftEntityPlacementServer::discardTree);
+                    sendResult(player, payload.nonce(), "INVALID_NBT", "");
+                    return;
+                }
+                passengers.add(entity);
+            }
+        } catch (RuntimeException ignored) {
+            passengers.forEach(QuickCraftEntityPlacementServer::discardTree);
+            sendResult(player, payload.nonce(), "INVALID_NBT", "");
+            return;
+        }
+        for (Entity passenger : passengers) {
+            if (!isTreeWithinReach(player, passenger, reach)
+                    || !isTreePlacementAllowed(level, player, passenger)
+                    || !isTreeInsideWorldBorder(level, passenger)
+                    || !canTreeStayAttached(passenger)) {
+                passengers.forEach(QuickCraftEntityPlacementServer::discardTree);
+                sendResult(player, payload.nonce(), "COLLISION", "");
+                return;
+            }
+        }
+
+        List<ItemStack> snapshot = creativeMaterialBypass
+                ? List.of()
+                : inventoryItems(player).stream().map(ItemStack::copy).toList();
+        if (!creativeMaterialBypass) consumeMaterials(player, required);
+        boolean added = true;
+        try {
+            for (Entity passenger : passengers) {
+                if (!level.tryAddFreshEntityWithPassengers(passenger)) {
+                    added = false;
+                    break;
+                }
+            }
+            if (added) {
+                for (Entity passenger : passengers) {
+                    if (!startRiding(passenger, vehicle)) {
+                        added = false;
+                        break;
+                    }
+                }
+            }
+        } catch (RuntimeException ignored) {
+            added = false;
+        }
+        if (!added) {
+            passengers.forEach(QuickCraftEntityPlacementServer::discardTree);
+            if (!creativeMaterialBypass) restoreInventory(player, snapshot);
+            sendResult(player, payload.nonce(), "INTERNAL_ERROR", "");
+            return;
+        }
+        for (int index = 0; index < passengerNbt.size(); index++) {
+            giveCopperChests(player, compoundAt(passengerNbt, index));
+        }
+        sendResult(player, payload.nonce(), "SUCCESS", "",
+                "quickcraft.entity_placement.result.passengers_added");
+    }
+
     public static void clear(ServerPlayer player) {
         if (player != null) SESSIONS.remove(player.getUUID());
     }
 
     private static void sendResult(ServerPlayer player, long nonce, String status, String uuid) {
+        sendResult(player, nonce, status, uuid, "");
+    }
+
+    private static void sendResult(
+            ServerPlayer player,
+            long nonce,
+            String status,
+            String uuid,
+            String messageKey
+    ) {
         ServerPlayNetworking.send(player, new QuickLitematicaEntityPlacementPayloads.ResultPayload(
-                nonce, status, uuid, ""));
+                nonce, status, uuid, messageKey));
+    }
+
+    private static boolean beginRequest(ServerPlayer player, String token, long nonce) {
+        Session session = SESSIONS.get(player.getUUID());
+        if (session == null || !session.token.equals(token)) {
+            sendResult(player, nonce, "DISABLED", "");
+            return false;
+        }
+        if (!session.enabled || !FGASettings.quickCraftEasyPlaceEntities) {
+            sendResult(player, nonce, "DISABLED", "");
+            return false;
+        }
+        if (session.nonces.contains(nonce)) {
+            sendResult(player, nonce, "REPLAYED_REQUEST", "");
+            return false;
+        }
+        if (session.nonces.size() >= MAX_NONCES) session.nonces.removeFirst();
+        session.nonces.add(nonce);
+        long tick = player.serverLevel().getGameTime();
+        if (session.lastRequestTick != Long.MIN_VALUE
+                && tick - session.lastRequestTick < REQUEST_COOLDOWN_TICKS) {
+            sendResult(player, nonce, "RATE_LIMITED", "");
+            return false;
+        }
+        session.lastRequestTick = tick;
+        return true;
     }
 
     private static double placementReach(ServerPlayer player) {
@@ -356,6 +492,21 @@ public final class QuickCraftEntityPlacementServer {
         return appendEntityTreeMaterials(root, level, materials, 0, count, player)
                 ? mergeMaterials(materials)
                 : null;
+    }
+
+    private static List<ItemStack> materialsForPassengers(
+            CompoundTag root,
+            ServerLevel level,
+            ServerPlayer player
+    ) {
+        List<ItemStack> materials = new ArrayList<>();
+        int[] count = {0};
+        ListTag passengers = listValue(root, "Passengers");
+        for (int index = 0; index < passengers.size(); index++) {
+            if (!appendEntityTreeMaterials(
+                    compoundAt(passengers, index), level, materials, 1, count, player)) return null;
+        }
+        return mergeMaterials(materials);
     }
 
     private static boolean appendEntityTreeMaterials(

--- a/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
+++ b/src/main/java/carpet/fga/QuickCraftEntityPlacementServer.java
@@ -137,7 +137,7 @@ public final class QuickCraftEntityPlacementServer {
             return;
         }
 
-        List<ItemStack> required = materialsForTree(requested, level);
+        List<ItemStack> required = materialsForTree(requested, level, player);
         if (required == null) {
             sendResult(player, payload.nonce(), "UNSUPPORTED_ENTITY", "");
             return;
@@ -345,10 +345,14 @@ public final class QuickCraftEntityPlacementServer {
         root.getPassengersAndSelf().toList().forEach(Entity::discard);
     }
 
-    private static List<ItemStack> materialsForTree(CompoundTag root, ServerLevel level) {
+    private static List<ItemStack> materialsForTree(
+            CompoundTag root,
+            ServerLevel level,
+            ServerPlayer player
+    ) {
         List<ItemStack> materials = new ArrayList<>();
         int[] count = {0};
-        return appendEntityTreeMaterials(root, level, materials, 0, count)
+        return appendEntityTreeMaterials(root, level, materials, 0, count, player)
                 ? mergeMaterials(materials)
                 : null;
     }
@@ -358,14 +362,17 @@ public final class QuickCraftEntityPlacementServer {
             ServerLevel level,
             List<ItemStack> materials,
             int depth,
-            int[] count
+            int[] count,
+            ServerPlayer player
     ) {
         if (depth > MAX_ENTITY_TREE_DEPTH || ++count[0] > MAX_ENTITY_TREE_SIZE) return false;
         String id = readEntityId(nbt);
         if (id == null || entityTypeForId(id) == null) return false;
-        ItemStack baseStack = stackForEntity(id, nbt, level);
-        if (baseStack == null || baseStack.isEmpty()) return false;
-        materials.add(baseStack);
+        if (!appendConstructedEntityMaterials(id, materials, player)) {
+            ItemStack baseStack = stackForEntity(id, nbt, level);
+            if (baseStack == null || baseStack.isEmpty()) return false;
+            materials.add(baseStack);
+        }
 
         if (!pathOf(id).equals("item") && !appendStoredItem(materials, nbt, "Item", level)) return false;
         for (String key : List.of("SaddleItem", "ArmorItem", "DecorItem", "body_armor_item")) {
@@ -381,7 +388,7 @@ public final class QuickCraftEntityPlacementServer {
 
         ListTag passengers = listValue(nbt, "Passengers");
         for (int i = 0; i < passengers.size(); i++) {
-            if (!appendEntityTreeMaterials(compoundAt(passengers, i), level, materials, depth + 1, count)) {
+            if (!appendEntityTreeMaterials(compoundAt(passengers, i), level, materials, depth + 1, count, player)) {
                 return false;
             }
         }
@@ -417,6 +424,66 @@ public final class QuickCraftEntityPlacementServer {
         if (direct != null) return new ItemStack(direct);
         Item egg = itemForId(namespaceOf(id), path + "_spawn_egg");
         return egg == null ? null : new ItemStack(egg);
+    }
+
+    private static boolean appendConstructedEntityMaterials(
+            String id,
+            List<ItemStack> materials,
+            ServerPlayer player
+    ) {
+        String path = pathOf(id);
+        Item spawnEgg = itemForId(namespaceOf(id), path + "_spawn_egg");
+        if (spawnEgg != null && hasInventoryItem(player, spawnEgg)) return false;
+        switch (path) {
+            case "snow_golem" -> {
+                materials.add(new ItemStack(constructionPumpkin(player)));
+                materials.add(new ItemStack(Items.SNOW_BLOCK, 2));
+                return true;
+            }
+        case "iron_golem" -> {
+            materials.add(new ItemStack(constructionPumpkin(player)));
+            materials.add(new ItemStack(Items.IRON_BLOCK, 4));
+            return true;
+        }
+        case "copper_golem" -> {
+            Item copperBlock = itemForId("minecraft", "copper_block");
+            if (copperBlock == null) return false;
+            materials.add(new ItemStack(copperBlock));
+            materials.add(new ItemStack(constructionPumpkin(player)));
+            Item copperChest = itemForId("minecraft", "copper_chest");
+            if (copperChest != null) materials.add(new ItemStack(copperChest));
+            return true;
+        }
+        case "wither" -> {
+            materials.add(new ItemStack(constructionWitherBase(player), 4));
+            materials.add(new ItemStack(Items.WITHER_SKELETON_SKULL, 3));
+            return true;
+        }
+            default -> {
+                return false;
+            }
+        }
+    }
+
+    private static boolean hasInventoryItem(ServerPlayer player, Item item) {
+        return player != null && inventoryItems(player).stream()
+                .anyMatch(stack -> stack.is(item) && !stack.isEmpty());
+    }
+
+    private static Item constructionPumpkin(ServerPlayer player) {
+        return hasInventoryItem(player, Items.CARVED_PUMPKIN)
+                ? Items.CARVED_PUMPKIN
+                : hasInventoryItem(player, Items.PUMPKIN)
+                ? Items.PUMPKIN
+                : Items.CARVED_PUMPKIN;
+    }
+
+    private static Item constructionWitherBase(ServerPlayer player) {
+        return hasInventoryItem(player, Items.SOUL_SAND)
+                ? Items.SOUL_SAND
+                : hasInventoryItem(player, Items.SOUL_SOIL)
+                ? Items.SOUL_SOIL
+                : Items.SOUL_SAND;
     }
 
     private static boolean appendStoredItem(

--- a/src/main/java/com/yiyihehe/quickcraft/litematica/QuickLitematicaEntityPlacementPayloads.java
+++ b/src/main/java/com/yiyihehe/quickcraft/litematica/QuickLitematicaEntityPlacementPayloads.java
@@ -12,6 +12,8 @@ import net.minecraft.resources.ResourceLocation;
 //#endif
 import net.minecraft.world.phys.Vec3;
 
+import java.util.UUID;
+
 /**
  * QuickCraft entity placement wire types shared with the client mod.
  * The binary name and record layouts must remain identical in both repositories because
@@ -19,7 +21,9 @@ import net.minecraft.world.phys.Vec3;
  */
 public final class QuickLitematicaEntityPlacementPayloads {
     public static final int PROTOCOL_VERSION = 2;
-    public static final int CLIENT_FEATURES = 0;
+    public static final int FEATURE_PASSENGER_SUPPLEMENT = 1;
+    public static final int CLIENT_FEATURES = FEATURE_PASSENGER_SUPPLEMENT;
+    public static final int SERVER_FEATURES = FEATURE_PASSENGER_SUPPLEMENT;
     public static final int MAX_CLIENT_NBT_BYTES = 262_144;
 
     private QuickLitematicaEntityPlacementPayloads() {
@@ -153,6 +157,58 @@ public final class QuickLitematicaEntityPlacementPayloads {
             buffer.writeFloat(yaw);
             buffer.writeFloat(pitch);
             writeVec3(buffer, velocity);
+            buffer.writeBoolean(creativeMaterialBypass);
+            buffer.writeNbt(entityNbt);
+        }
+
+        @Override
+        public Type<? extends CustomPacketPayload> type() {
+            return ID;
+        }
+    }
+
+    public record PassengerRequestPayload(
+            String sessionToken,
+            long nonce,
+            //#if MC >= 1.21.11
+            //$$ Identifier dimension,
+            //#else
+            ResourceLocation dimension,
+            //#endif
+            UUID vehicleUuid,
+            boolean creativeMaterialBypass,
+            CompoundTag entityNbt
+    ) implements CustomPacketPayload {
+        //#if MC >= 1.21.11
+        //$$ public static final Type<PassengerRequestPayload> ID = new Type<>(
+        //$$         Identifier.fromNamespaceAndPath("quickcraft", "entity_place_passengers"));
+        //#else
+        public static final Type<PassengerRequestPayload> ID = new Type<>(
+                ResourceLocation.fromNamespaceAndPath("quickcraft", "entity_place_passengers"));
+        //#endif
+        public static final StreamCodec<FriendlyByteBuf, PassengerRequestPayload> CODEC =
+                CustomPacketPayload.codec(PassengerRequestPayload::write, PassengerRequestPayload::new);
+
+        public PassengerRequestPayload(FriendlyByteBuf buffer) {
+            //#if MC >= 1.21.11
+            //$$ this(buffer.readUtf(128), buffer.readLong(), buffer.readIdentifier(),
+            //$$         new UUID(buffer.readLong(), buffer.readLong()), buffer.readBoolean(), buffer.readNbt());
+            //#else
+            this(buffer.readUtf(128), buffer.readLong(), buffer.readResourceLocation(),
+                    new UUID(buffer.readLong(), buffer.readLong()), buffer.readBoolean(), buffer.readNbt());
+            //#endif
+        }
+
+        private void write(FriendlyByteBuf buffer) {
+            buffer.writeUtf(sessionToken, 128);
+            buffer.writeLong(nonce);
+            //#if MC >= 1.21.11
+            //$$ buffer.writeIdentifier(dimension);
+            //#else
+            buffer.writeResourceLocation(dimension);
+            //#endif
+            buffer.writeLong(vehicleUuid.getMostSignificantBits());
+            buffer.writeLong(vehicleUuid.getLeastSignificantBits());
             buffer.writeBoolean(creativeMaterialBypass);
             buffer.writeNbt(entityNbt);
         }


### PR DESCRIPTION
同步 QuickCraft 实体放置协议的服务端实现：

- 支持生成蛋优先、傀儡/凋灵构造材料以及复杂乘客树的原子校验。
- 按原版铜傀儡生成逻辑，在成功生成后返还铜箱子。
- 新增向已有空载具补放整棵乘客树的请求；仅扣除乘客材料，生成或骑乘失败时回滚实体和背包。
- 通过 feature bit 协商补放能力，保持协议 v2；旧客户端与不支持该能力的服务端仍可使用原有放置功能。
- 服务端再次校验会话、维度、距离、权限、载具类型、空载状态、NBT 和材料，避免重复补放或重复扣除。

本地已通过 1.21、1.21.1、1.21.3、1.21.4、1.21.5、1.21.8、1.21.10、1.21.11、26.1.2、26.2 的 compileJava；1.21.1 完整 build 通过。