### PR TITLE
fix: preserve hopper rule-off compatibility on 1.21.1 and 26.2

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -70,6 +70,8 @@
 
 `entityDropRemoval` 是纯服务端规则，在 Minecraft 1.21+ 注册。使用 `/entityDropRemoval set <生物ID> <物品ID|allEquipment>` 增加配置，`remove` 删除单项，`list` 查看全部配置，`list <生物ID>` 查看默认战利品表和当前可识别的掉落配置。指定物品会过滤该生物死亡流程中的战利品表、装备和 `spawnAtLocation` 匹配物品；`allEquipment` 只过滤头盔、胸甲、护腿、靴子、主手和副手，不会误删战利品表中的同名物品。规则为 `false` 时命令隐藏且掉落保持原版；`true`、`ops` 或 `0-4` 控制命令权限。配置保存于 `world/config/carpetfgaaddition/entity-drop-removal.json`，采用原子替换，损坏文件会保留并在本次运行禁用配置。列表中的红色减号可点击删除对应配置。
 
+在 Minecraft `1.21.1` 和 `26.2`，关闭 `droppedItemStackLimit` 时漏斗与漏斗矿车保留原掉落物吸取调用链。开启时超量堆叠每次最多尝试一个 batch，并保留其他 Mod 的内部搬运限制；剩余物品等待后续吸取。
+
 ## 深板岩切石与玩家加载距离
 
 | 规则 | 类型 | 默认值 | 可选值 | 生效版本 | 说明 |

--- a/docs/rules_en.md
+++ b/docs/rules_en.md
@@ -70,6 +70,8 @@ The legacy `preStackMobDeathDrops` and `preStackMobDeathDropsRange` rules are hi
 
 `entityDropRemoval` is server-side only and is registered on Minecraft 1.21+. Use `/entityDropRemoval set <entity id> <item id|allEquipment>` to add an entry, `remove` to delete one, `list` to inspect all configured entities, and `list <entity id>` to inspect the default loot table and currently identifiable drop configuration. Item entries filter matching items in the entity's death flow, including loot-table, equipment, and `spawnAtLocation` output. `allEquipment` filters only the helmet, chestplate, leggings, boots, main-hand, and off-hand slots, so a same-named loot-table item is kept. `false` hides and blocks the command; `true`, `ops`, and `0-4` control command access. The file is `world/config/carpetfgaaddition/entity-drop-removal.json`, written with atomic replacement; corrupt files are preserved and disabled for the current run. Red minus buttons in list output remove entries.
 
+On Minecraft `1.21.1` and `26.2`, disabling `droppedItemStackLimit` preserves the original hopper and hopper-minecart item-entity transfer chain. When enabled, oversized stacks make at most one batch attempt per transfer, preserving other mods' inner transfer limits and leaving the remainder for later attempts.
+
 ## Deepslate stonecutting and player loading
 
 | Rule | Type | Default | Values | Effective versions | Description |

--- a/scripts/tests/hopper-compat.gradle
+++ b/scripts/tests/hopper-compat.gradle
@@ -1,0 +1,26 @@
+// Opt-in test mod: never included in the distributable main jar.
+gradle.afterProject { p ->
+    // The preprocessor links source sets through every intermediate graph node.
+    if (p != p.rootProject) {
+        def smoke = p.sourceSets.create('hopperCompat')
+        if (p.name == '1.21.1') {
+            smoke.java.srcDir p.rootProject.file('scripts/tests/hopper-compat/java')
+            smoke.resources.srcDir p.rootProject.file('scripts/tests/hopper-compat/resources')
+        }
+        smoke.compileClasspath += p.sourceSets.main.compileClasspath + p.sourceSets.main.output
+        smoke.runtimeClasspath += p.sourceSets.main.runtimeClasspath
+        p.tasks.named(smoke.compileJavaTaskName) {
+            setSource(p.rootProject.fileTree('scripts/tests/hopper-compat/java') { include '**/*.java' })
+        }
+        p.tasks.named(smoke.processResourcesTaskName) {
+            def priority = p.findProperty('compatPriority') ?: '1100'
+            inputs.property('compatPriority', priority)
+            filesMatching('*.mixins.json') {
+                filter { line -> line.replace('"priority": 1100', '"priority": ' + priority) }
+            }
+        }
+        p.loom.mods.create('fga_hopper_compat_test') { sourceSet smoke }
+        p.loom.runs.named('server') { source smoke }
+        p.tasks.named('runServer') { dependsOn p.tasks.named(smoke.classesTaskName) }
+    }
+}

--- a/scripts/tests/hopper-compat.md
+++ b/scripts/tests/hopper-compat.md
@@ -1,0 +1,29 @@
+# Hopper rule isolation regression
+
+Build `:1.21.1:build` with Java 21 and `:26.2:build` with Java 25, then run:
+
+```powershell
+python scripts/tests/run-rule-compat.py --version 1.21.1 --suite hopper-compat
+python scripts/tests/run-rule-compat.py --version 26.2 --suite hopper-compat
+python scripts/tests/run-rule-compat.py --version 1.21.1 --suite hopper-compat --priority 900
+python scripts/tests/run-rule-compat.py --version 26.2 --suite hopper-compat --priority 900
+```
+
+The opt-in test mod wraps the actual ItemEntity transfer call, imposing a one-item
+allowance like a compatibility mod. It verifies block-container and hopper-minecart
+targets, enabled/disabled rules, original input count when disabled, one inner call,
+partial-transfer return values, one bounded stone batch and a full destination.
+The default synthetic mixin priority is 1100; 900 covers the other side of FGA's
+default priority. The test mod is a separate source set and is not packaged in FGA.
+
+The runner requires a PASS marker as well as a successful process exit. It creates
+disposable worlds under the version run directory, backs up/restores launch settings,
+and retains logs and worlds for diagnosis. It never opens a real saved world.
+
+Only 1.21.1 and 26.2 receive the new implementation. The other seven build nodes
+retain their prior code for a later port. Preprocessor source-set dependencies may
+compile intermediate nodes even when only the 26.2 task is requested.
+
+This synthetic test does not certify a particular Org Addition release. Test Org
+alone versus Org + FGA disabled in a disposable world before claiming that pairing.
+Chest-to-minecart extraction is a separate path and is not covered by this suite.

--- a/scripts/tests/hopper-compat/java/fga/test/HopperCompatTest.java
+++ b/scripts/tests/hopper-compat/java/fga/test/HopperCompatTest.java
@@ -1,0 +1,79 @@
+package fga.test;
+
+import carpet.fga.FGASettings;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.HopperBlockEntity;
+
+public class HopperCompatTest implements ModInitializer {
+    public static int calls, seenCount;
+    public static boolean oneAtATime;
+    private static int checks;
+
+    public void onInitialize() {
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            try {
+                ServerLevel level = server.overworld();
+                for (String rule : new String[]{"false", "true"}) {
+                    FGASettings.droppedItemStackLimit = rule;
+                    for (boolean cart : new boolean[]{false, true}) {
+                        Container target = cart ? newCart(level) : new SimpleContainer(5);
+                        oneAtATime = true;
+                        calls = 0;
+                        ItemEntity entity = new ItemEntity(level, 0, 100, 0, new ItemStack(Items.SHULKER_BOX, 6));
+                        boolean complete = HopperBlockEntity.addItem(target, entity);
+                        check(calls == 1, "one wrapped call " + rule + "/" + cart);
+                        check(!complete && entity.getItem().getCount() == 5, "partial result and count");
+                        check(target.getItem(0).getCount() == 1 && target.getItem(1).isEmpty(), "one slot only");
+                        if (rule.equals("false")) check(seenCount == 6, "off passes original count");
+                    }
+                }
+                FGASettings.droppedItemStackLimit = "true";
+                oneAtATime = false;
+                Container target = new SimpleContainer(5);
+                ItemEntity entity = new ItemEntity(level, 0, 100, 0, new ItemStack(Items.STONE, 200));
+                calls = 0;
+                check(!HopperBlockEntity.addItem(target, entity), "oversized transfer is partial");
+                check(calls == 1 && target.getItem(0).getCount() == 64 && entity.getItem().getCount() == 136,
+                        "one bounded batch without item loss");
+                for (int slot = 0; slot < 5; slot++) target.setItem(slot, new ItemStack(Items.STONE, 64));
+                calls = 0;
+                check(!HopperBlockEntity.addItem(target, entity) && entity.getItem().getCount() == 136 && calls == 1,
+                        "full target preserves remainder");
+                System.out.println("FGA_HOPPER_COMPAT_PASS checks=" + checks);
+            } catch (Throwable failure) {
+                System.out.println("FGA_HOPPER_COMPAT_FAIL " + failure);
+                failure.printStackTrace();
+            } finally {
+                FGASettings.droppedItemStackLimit = "false";
+                server.halt(false);
+            }
+        });
+    }
+
+    private static Container newCart(Level level) throws Exception {
+        Class<?> cart, types;
+        try {
+            cart = Class.forName("net.minecraft.world.entity.vehicle.MinecartHopper");
+            types = EntityType.class;
+        } catch (ClassNotFoundException changedPackage) {
+            cart = Class.forName("net.minecraft.world.entity.vehicle.minecart.MinecartHopper");
+            types = Class.forName("net.minecraft.world.entity.EntityTypes");
+        }
+        return (Container) cart.getConstructor(EntityType.class, Level.class)
+                .newInstance(types.getField("HOPPER_MINECART").get(null), level);
+    }
+
+    private static void check(boolean condition, String name) {
+        if (!condition) throw new AssertionError(name);
+        checks++;
+    }
+}

--- a/scripts/tests/hopper-compat/java/fga/test/mixin/HopperCompatMixin.java
+++ b/scripts/tests/hopper-compat/java/fga/test/mixin/HopperCompatMixin.java
@@ -1,0 +1,31 @@
+package fga.test.mixin;
+
+import fga.test.HopperCompatTest;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.core.Direction;
+import net.minecraft.world.Container;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.HopperBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = HopperBlockEntity.class)
+public class HopperCompatMixin {
+    @WrapOperation(method = "addItem(Lnet/minecraft/world/Container;Lnet/minecraft/world/entity/item/ItemEntity;)Z",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/HopperBlockEntity;addItem(Lnet/minecraft/world/Container;Lnet/minecraft/world/Container;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/core/Direction;)Lnet/minecraft/world/item/ItemStack;"))
+    private static ItemStack probe(Container source, Container target, ItemStack stack, Direction direction,
+                                   Operation<ItemStack> original) {
+        HopperCompatTest.calls++;
+        HopperCompatTest.seenCount = stack.getCount();
+        if (HopperCompatTest.oneAtATime) {
+            if (target.getItem(0).isEmpty()) {
+                target.setItem(0, stack.copyWithCount(1));
+                return stack.copyWithCount(stack.getCount() - 1);
+            }
+            return stack;
+        }
+        return original.call(source, target, stack, direction);
+    }
+}

--- a/scripts/tests/hopper-compat/resources/fabric.mod.json
+++ b/scripts/tests/hopper-compat/resources/fabric.mod.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "id": "fga_hopper_compat_test",
+  "version": "1.0.0",
+  "environment": "server",
+  "entrypoints": { "main": ["fga.test.HopperCompatTest"] },
+  "mixins": ["hopper-compat.mixins.json"]
+}

--- a/scripts/tests/hopper-compat/resources/hopper-compat.mixins.json
+++ b/scripts/tests/hopper-compat/resources/hopper-compat.mixins.json
@@ -1,0 +1,8 @@
+{
+  "required": true,
+  "priority": 1100,
+  "package": "fga.test.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": ["HopperCompatMixin"],
+  "injectors": { "defaultRequire": 1 }
+}

--- a/scripts/tests/run-rule-compat.py
+++ b/scripts/tests/run-rule-compat.py
@@ -1,0 +1,62 @@
+"""Run an opt-in test mod on an isolated dedicated-server world; retain logs/world for diagnosis."""
+import argparse
+import datetime
+import json
+import os
+import re
+from pathlib import Path
+import subprocess
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', required=True, choices=['1.21.1', '26.2'])
+parser.add_argument('--suite', required=True)
+parser.add_argument('--world', help='Reuse a named test world to verify a real process restart')
+parser.add_argument('--priority', choices=['900', '1100'], default='1100')
+args = parser.parse_args()
+if not re.fullmatch(r'[a-z0-9-]+', args.suite):
+    parser.error('suite must contain only lowercase letters, digits and hyphens')
+if args.world and not re.fullmatch(r'rule-compat-[a-zA-Z0-9-]+', args.world):
+    parser.error('world must start with rule-compat- and contain only letters, digits and hyphens')
+root = Path(__file__).resolve().parents[2]
+stamp = datetime.datetime.now().strftime('%Y%m%d-%H%M%S-%f')
+run = root / 'versions' / args.version / 'run'
+run.mkdir(parents=True, exist_ok=True)
+report = root / 'scripts' / 'logs' / f'{args.suite}-{args.version}-{stamp}'
+report.mkdir(parents=True)
+log = report / 'server.log'
+backups = {name: (run / name).read_bytes() if (run / name).exists() else None
+           for name in ['eula.txt', 'server.properties']}
+env = dict(os.environ)
+env['JAVA_HOME'] = 'C:/Program Files/Java/' + ('jdk-25.0.3' if args.version == '26.2' else 'jdk-21.0.11')
+try:
+    (run / 'eula.txt').write_text('eula=true\n')
+    (run / 'server.properties').write_text(
+        f'online-mode=false\nserver-port=0\nview-distance=2\nsimulation-distance=2\n'
+        f'level-name={args.world or ("rule-compat-" + args.suite + "-" + stamp)}\n')
+    command = [str(root / 'gradlew.bat'), f':{args.version}:runServer', '-I',
+               f'scripts/tests/{args.suite}.gradle', f'-PcompatPriority={args.priority}',
+               '--no-daemon', '--configure-on-demand', '--max-workers=2']
+    with log.open('w', encoding='utf-8') as output:
+        process = subprocess.Popen(command, cwd=root, env=env, stdin=subprocess.PIPE,
+                                   stdout=output, stderr=subprocess.STDOUT,
+                                   creationflags=subprocess.CREATE_NO_WINDOW)
+        try:
+            code = process.wait(timeout=480)
+        except subprocess.TimeoutExpired:
+            subprocess.run(['taskkill', '/PID', str(process.pid), '/T', '/F'], capture_output=True)
+            raise
+    text = log.read_text(encoding='utf-8', errors='replace')
+    marker = 'FGA_' + args.suite.upper().replace('-', '_') + '_PASS'
+    passed = code == 0 and marker in text and 'COMPAT_FAIL' not in text
+    result = dict(version=args.version, suite=args.suite, priority=args.priority, passed=passed, exitCode=code, log=str(log))
+    (report / 'summary.json').write_text(json.dumps(result, indent=2))
+    print(json.dumps(result))
+    if not passed:
+        print(text[-7000:])
+        raise SystemExit(1)
+finally:
+    for name, content in backups.items():
+        if content is None:
+            (run / name).unlink(missing_ok=True)
+        else:
+            (run / name).write_bytes(content)

--- a/src/main/java/carpet/fga/mixin/HopperBlockEntityMixin.java
+++ b/src/main/java/carpet/fga/mixin/HopperBlockEntityMixin.java
@@ -3,6 +3,10 @@ package carpet.fga.mixin;
 
 import carpet.fga.FGACompat;
 import carpet.fga.FGASettings;
+//#if MC == 1.21.1 || MC == 26.2
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+//#endif
 import net.minecraft.core.Direction;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -20,75 +24,96 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(HopperBlockEntity.class)
 public abstract class HopperBlockEntityMixin {
-    @Inject(
+    //#if MC == 1.21.1 || MC == 26.2
+    @WrapOperation(
             method = "addItem(Lnet/minecraft/world/Container;Lnet/minecraft/world/entity/item/ItemEntity;)Z",
-            at = @At("HEAD"),
-            cancellable = true
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/HopperBlockEntity;addItem(Lnet/minecraft/world/Container;Lnet/minecraft/world/Container;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/core/Direction;)Lnet/minecraft/world/item/ItemStack;")
     )
-    private static void carpetFga$insertOversizedItemEntity(Container destination, ItemEntity itemEntity,
-                                                             CallbackInfoReturnable<Boolean> cir) {
-        ItemStack original = itemEntity.getItem();
-        //#if MC >= 1.21 && MC <= 26.2
-        // Carpet Org can temporarily make shulker boxes stackable. A hopper minecart
-        // must still consume at most one box per item-entity transfer attempt.
-        if (destination instanceof MinecartHopper
-                && original.getCount() > 1
-                && original.getItem() instanceof BlockItem blockItem
-                && blockItem.getBlock() instanceof ShulkerBoxBlock) {
-            ItemStack one = FGACompat.copyWithCount(original, 1);
-            ItemStack rejected = HopperBlockEntity.addItem(null, destination, one, (Direction) null);
-            if (rejected.isEmpty()) {
-                original.shrink(1);
-                if (original.isEmpty()) {
-                    itemEntity.setItem(ItemStack.EMPTY);
-                    FGACompat.discard(itemEntity);
-                } else {
-                    itemEntity.setItem(original);
-                }
-                cir.setReturnValue(true);
-            }
-            return;
+    private static ItemStack carpetFga$insertOneOversizedBatch(Container source, Container destination,
+            ItemStack stack, Direction direction, Operation<ItemStack> original) {
+        if (!FGASettings.isDroppedItemStackLimitEnabled()) {
+            return original.call(source, destination, stack, direction);
         }
+        int batchLimit = Math.min(stack.getMaxStackSize(), destination.getMaxStackSize(stack));
+        if (batchLimit <= 0 || stack.getCount() <= batchLimit) {
+            return original.call(source, destination, stack, direction);
+        }
+        // Keep one transfer attempt and its wrappers; never repeat another mod's per-call allowance.
+        int deferred = stack.getCount() - batchLimit;
+        ItemStack rejected = original.call(source, destination, FGACompat.copyWithCount(stack, batchLimit), direction);
+        return FGACompat.copyWithCount(stack, deferred + rejected.getCount());
+    }
+    //#else
+//$$     @Inject(
+//$$             method = "addItem(Lnet/minecraft/world/Container;Lnet/minecraft/world/entity/item/ItemEntity;)Z",
+//$$             at = @At("HEAD"),
+//$$             cancellable = true
+//$$     )
+//$$     private static void carpetFga$insertOversizedItemEntity(Container destination, ItemEntity itemEntity,
+//$$                                                              CallbackInfoReturnable<Boolean> cir) {
+//$$         ItemStack original = itemEntity.getItem();
+        //#if MC >= 1.21 && MC <= 26.2
+//$$         // Carpet Org can temporarily make shulker boxes stackable. A hopper minecart
+//$$         // must still consume at most one box per item-entity transfer attempt.
+//$$         if (destination instanceof MinecartHopper
+//$$                 && original.getCount() > 1
+//$$                 && original.getItem() instanceof BlockItem blockItem
+//$$                 && blockItem.getBlock() instanceof ShulkerBoxBlock) {
+//$$             ItemStack one = FGACompat.copyWithCount(original, 1);
+//$$             ItemStack rejected = HopperBlockEntity.addItem(null, destination, one, (Direction) null);
+//$$             if (rejected.isEmpty()) {
+//$$                 original.shrink(1);
+//$$                 if (original.isEmpty()) {
+//$$                     itemEntity.setItem(ItemStack.EMPTY);
+//$$                     FGACompat.discard(itemEntity);
+//$$                 } else {
+//$$                     itemEntity.setItem(original);
+//$$                 }
+//$$                 cir.setReturnValue(true);
+//$$             }
+//$$             return;
+//$$         }
         //#endif
 
-        if (!FGASettings.isDroppedItemStackLimitEnabled()) {
-            return;
-        }
+//$$         if (!FGASettings.isDroppedItemStackLimitEnabled()) {
+//$$             return;
+//$$         }
 
-        int batchLimit = Math.min(original.getMaxStackSize(),
+//$$         int batchLimit = Math.min(original.getMaxStackSize(),
                 //#if MC >= 1.20.5
-                destination.getMaxStackSize(original)
+//$$                 destination.getMaxStackSize(original)
                 //#else
                 //$$ destination.getMaxStackSize()
                 //#endif
-        );
-        if (original.getCount() <= batchLimit) {
-            return;
-        }
+//$$         );
+//$$         if (original.getCount() <= batchLimit) {
+//$$             return;
+//$$         }
 
-        ItemStack remaining = original.copy();
-        while (!remaining.isEmpty()) {
-            int batchSize = Math.min(remaining.getCount(), batchLimit);
-            ItemStack batch = FGACompat.copyWithCount(remaining, batchSize);
-            ItemStack rejected = HopperBlockEntity.addItem(null, destination, batch, (Direction) null);
-            int inserted = batchSize - rejected.getCount();
-            if (inserted <= 0) {
-                break;
-            }
-            remaining.shrink(inserted);
-            if (inserted < batchSize) {
-                break;
-            }
-        }
+//$$         ItemStack remaining = original.copy();
+//$$         while (!remaining.isEmpty()) {
+//$$             int batchSize = Math.min(remaining.getCount(), batchLimit);
+//$$             ItemStack batch = FGACompat.copyWithCount(remaining, batchSize);
+//$$             ItemStack rejected = HopperBlockEntity.addItem(null, destination, batch, (Direction) null);
+//$$             int inserted = batchSize - rejected.getCount();
+//$$             if (inserted <= 0) {
+//$$                 break;
+//$$             }
+//$$             remaining.shrink(inserted);
+//$$             if (inserted < batchSize) {
+//$$                 break;
+//$$             }
+//$$         }
 
-        if (remaining.isEmpty()) {
-            itemEntity.setItem(ItemStack.EMPTY);
-            FGACompat.discard(itemEntity);
-            cir.setReturnValue(true);
-        } else {
-            itemEntity.setItem(remaining);
-            cir.setReturnValue(false);
-        }
-    }
+//$$         if (remaining.isEmpty()) {
+//$$             itemEntity.setItem(ItemStack.EMPTY);
+//$$             FGACompat.discard(itemEntity);
+//$$             cir.setReturnValue(true);
+//$$         } else {
+//$$             itemEntity.setItem(remaining);
+//$$             cir.setReturnValue(false);
+//$$         }
+//$$     }
+    //#endif
 }
 //#endif


### PR DESCRIPTION
On Minecraft 1.21.1 and 26.2, disabling droppedItemStackLimit now passes the original hopper ItemEntity transfer through unchanged. Replace the HEAD cancellation, unconditional shulker special case and repeated batch loop with one wrapped inner transfer. Enabled oversized transfers leave the remainder for subsequent attempts and retain the vanilla partial-transfer return semantics.

Other seven build nodes retain their previous implementation for the explicitly deferred port. Configuration, network protocol and defaults are unchanged. Bilingual rule documentation describes the two-version scope.

Validation:
- Both :1.21.1:build (Java 21) and :26.2:build (Java 25) passed; artifacts archived separately.
- Actual dedicated-server synthetic compatibility mod passed 17 checks on each target version. It checks a one-item allowance, both ordinary container and hopper-minecart targets, rule-off input count, exactly one wrapped call, partial returns, oversized stone and full destinations.
- Both priorities 900 and 1100 passed on both target versions (17 assertions per run).
- git diff --check passed.

The test mod is separate from the distributable main jar. This is not a fresh real Org Addition test, and chest-to-minecart extraction remains a separate unverified path. Existing unrelated build warnings were not suppressed.

Merge with Squash only.
