### PR TITLE
fix: gate scoped stack limits on 1.21.1 and 26.2

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -92,6 +92,8 @@
 
 `list` 按页显示中文名称、完整物品 ID 和数量；列表中的删除按钮可点击执行对应命令。配置损坏时保持原版安全限制并拒绝写入。
 
+在 `1.21.1` 和 `26.2`，`inventoryLimit` / `containerLimit` 的保存值与是否生效分开：主规则关闭（含重启后）时不应用，重新开启后恢复；关闭操作不会清空配置。
+
 ## `/entityDropRemoval` 与 `/fga entityDropRemoval`
 
 相关规则：`entityDropRemoval`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -82,6 +82,10 @@
 /droppedItemStackLimit mode all <数量>
 /droppedItemStackLimit mode black <数量>
 /droppedItemStackLimit mode whitelist
+/droppedItemStackLimit mode inventory <数量>
+/droppedItemStackLimit mode container <数量>
+/droppedItemStackLimit reset inventory
+/droppedItemStackLimit reset container
 /droppedItemStackLimit set black <物品ID>
 /droppedItemStackLimit remove black <物品ID>
 /droppedItemStackLimit set whitelist <物品ID> <数量>

--- a/docs/commands_en.md
+++ b/docs/commands_en.md
@@ -82,6 +82,10 @@ Options can be combined: `pathfinding`, `reach <0.1-64>`, `airPlace`, `ignoreObs
 /droppedItemStackLimit mode all <count>
 /droppedItemStackLimit mode black <count>
 /droppedItemStackLimit mode whitelist
+/droppedItemStackLimit mode inventory <count>
+/droppedItemStackLimit mode container <count>
+/droppedItemStackLimit reset inventory
+/droppedItemStackLimit reset container
 /droppedItemStackLimit set black <item id>
 /droppedItemStackLimit remove black <item id>
 /droppedItemStackLimit set whitelist <item id> <count>

--- a/docs/commands_en.md
+++ b/docs/commands_en.md
@@ -92,6 +92,8 @@ Options can be combined: `pathfinding`, `reach <0.1-64>`, `airPlace`, `ignoreObs
 
 `list` is paged and shows the display name, full item ID, and count. List entries provide clickable removal commands. Invalid configuration keeps vanilla-safe limits and rejects writes.
 
+On `1.21.1` and `26.2`, saved `inventoryLimit` / `containerLimit` values are separate from activation: disabling the main rule, including across a restart, stops applying them without clearing them; re-enabling restores them.
+
 ## `/entityDropRemoval` and `/fga entityDropRemoval`
 
 Related rule: `entityDropRemoval`

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -72,6 +72,8 @@
 
 在 Minecraft `1.21.1` 和 `26.2`，关闭 `droppedItemStackLimit` 时漏斗与漏斗矿车保留原掉落物吸取调用链。开启时超量堆叠每次最多尝试一个 batch，并保留其他 Mod 的内部搬运限制；剩余物品等待后续吸取。
 
+在 Minecraft `1.21.1` 和 `26.2`，关闭 `droppedItemStackLimit` 会停止应用 `inventoryLimit` 和 `containerLimit`，包括重新加载配置与服务器重启之后。保存的非零值不会被删除，重新开启规则后恢复生效。
+
 ## 深板岩切石与玩家加载距离
 
 | 规则 | 类型 | 默认值 | 可选值 | 生效版本 | 说明 |

--- a/docs/rules_en.md
+++ b/docs/rules_en.md
@@ -72,6 +72,8 @@ The legacy `preStackMobDeathDrops` and `preStackMobDeathDropsRange` rules are hi
 
 On Minecraft `1.21.1` and `26.2`, disabling `droppedItemStackLimit` preserves the original hopper and hopper-minecart item-entity transfer chain. When enabled, oversized stacks make at most one batch attempt per transfer, preserving other mods' inner transfer limits and leaving the remainder for later attempts.
 
+On Minecraft `1.21.1` and `26.2`, disabling `droppedItemStackLimit` disables the effective `inventoryLimit` and `containerLimit`, including after configuration reload and server restart. Saved nonzero values are retained and take effect again when the rule is re-enabled.
+
 ## Deepslate stonecutting and player loading
 
 | Rule | Type | Default | Values | Effective versions | Description |

--- a/scripts/tests/scoped-compat.gradle
+++ b/scripts/tests/scoped-compat.gradle
@@ -1,0 +1,17 @@
+gradle.afterProject { p ->
+    if (p != p.rootProject) {
+        def smoke = p.sourceSets.create('scopedCompat')
+        if (p.name == '1.21.1') {
+            smoke.java.srcDir p.rootProject.file('scripts/tests/scoped-compat/java')
+            smoke.resources.srcDir p.rootProject.file('scripts/tests/scoped-compat/resources')
+        }
+        smoke.compileClasspath += p.sourceSets.main.compileClasspath + p.sourceSets.main.output
+        smoke.runtimeClasspath += p.sourceSets.main.runtimeClasspath
+        p.tasks.named(smoke.compileJavaTaskName) {
+            setSource(p.rootProject.fileTree('scripts/tests/scoped-compat/java') { include '**/*.java' })
+        }
+        p.loom.mods.create('fga_scoped_compat_test') { sourceSet smoke }
+        p.loom.runs.named('server') { source smoke }
+        p.tasks.named('runServer') { dependsOn p.tasks.named(smoke.classesTaskName) }
+    }
+}

--- a/scripts/tests/scoped-compat.md
+++ b/scripts/tests/scoped-compat.md
@@ -1,0 +1,24 @@
+# Scoped limit activation regression
+
+After building each target, run these commands twice with the same fresh test-world
+name (use a new name for a new run):
+
+```powershell
+python scripts/tests/run-rule-compat.py --version 1.21.1 --suite scoped-compat --world rule-compat-scoped-example
+python scripts/tests/run-rule-compat.py --version 26.2 --suite scoped-compat --world rule-compat-scoped-example
+```
+
+World directories are separate per version. The first run verifies a fresh default,
+enable/set/disable, effective inventory limits, actual Container and Slot consumers,
+client-requirement predicates, in-process reload, unchanged saved bytes, re-enable,
+and unstackable items. It also damages only the disposable configuration, verifies
+safe loading and refusal to overwrite that damaged file, and restores the test file.
+The second server process must report `restarted=true` and retained nonzero scopes
+that are ineffective while the rule is disabled.
+
+This suite requires the independent stack-client requirement fix (#15). Its client
+checks exercise the actual predicate, not network login or reconnect. The Inventory
+method fallback for synthetic item maxima above 99 is a separate regression suite.
+
+The source-set test mod is opt-in and is never included in the normal FGA jar.
+The two-version runner is provided by the independent hopper compatibility change.

--- a/scripts/tests/scoped-compat/java/fga/scopedtest/ScopedCompatTest.java
+++ b/scripts/tests/scoped-compat/java/fga/scopedtest/ScopedCompatTest.java
@@ -25,6 +25,7 @@ public class ScopedCompatTest implements ModInitializer {
                 check(FGASettings.droppedItemStackLimit.equals("false"), "default/persisted-off rule");
                 check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 64, "off inventory");
                 check(DroppedItemStackLimitConfig.effectiveContainerLimit(stone) == 64, "off container");
+                check(!DroppedItemStackLimitConfig.requiresModdedClient(), "off client requirement");
                 if (restarted) {
                     check(DroppedItemStackLimitConfig.snapshot().inventoryLimit() == 1000
                             && DroppedItemStackLimitConfig.snapshot().containerLimit() == 1000, "restart retains scopes");
@@ -34,12 +35,14 @@ public class ScopedCompatTest implements ModInitializer {
                 DroppedItemStackLimitConfig.setContainerLimit(1000);
                 byte[] saved = Files.readAllBytes(config);
                 check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 1000, "on inventory");
+                check(DroppedItemStackLimitConfig.requiresModdedClient(), "on client requirement");
                 check(new SimpleContainer(1).getMaxStackSize(stone) == 1000, "on container consumer");
                 FGASettings.droppedItemStackLimit = "false";
                 check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 64, "toggle inventory");
                 SimpleContainer container = new SimpleContainer(1);
                 check(container.getMaxStackSize(stone) == 64, "toggle container");
                 check(new Slot(container, 0, 0, 0).getMaxStackSize(stone) == 64, "toggle slot");
+                check(!DroppedItemStackLimitConfig.requiresModdedClient(), "toggle client requirement");
                 DroppedItemStackLimitConfig.load(server);
                 check(DroppedItemStackLimitConfig.effectiveContainerLimit(stone) == 64, "reload while off");
                 check(Arrays.equals(saved, Files.readAllBytes(config)), "off/reload preserve file bytes");
@@ -47,6 +50,18 @@ public class ScopedCompatTest implements ModInitializer {
                 check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 1000, "reenable retained scope");
                 check(DroppedItemStackLimitConfig.effectiveInventoryLimit(new ItemStack(Items.DIAMOND_SWORD)) == 1,
                         "unstackable stays unstackable");
+                Files.writeString(config, "{broken");
+                DroppedItemStackLimitConfig.load(server);
+                check(DroppedItemStackLimitConfig.isLoadFailed()
+                        && DroppedItemStackLimitConfig.effectiveContainerLimit(stone) == 64, "failed load is disabled");
+                try {
+                    DroppedItemStackLimitConfig.setContainerLimit(2000);
+                    throw new AssertionError("save after failed load must reject");
+                } catch (java.io.IOException expected) {
+                    check(Files.readString(config).equals("{broken"), "failed save preserves damaged file");
+                }
+                Files.write(config, saved);
+                DroppedItemStackLimitConfig.load(server);
                 FGASettings.droppedItemStackLimit = "false";
                 System.out.println("FGA_SCOPED_COMPAT_PASS checks=" + checks + " restarted=" + restarted);
             } catch (Throwable failure) {

--- a/scripts/tests/scoped-compat/java/fga/scopedtest/ScopedCompatTest.java
+++ b/scripts/tests/scoped-compat/java/fga/scopedtest/ScopedCompatTest.java
@@ -1,0 +1,64 @@
+package fga.scopedtest;
+
+import carpet.fga.DroppedItemStackLimitConfig;
+import carpet.fga.FGASettings;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.storage.LevelResource;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+public class ScopedCompatTest implements ModInitializer {
+    private static int checks;
+    public void onInitialize() {
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            try {
+                ItemStack stone = new ItemStack(Items.STONE);
+                Path config = server.getWorldPath(LevelResource.ROOT)
+                        .resolve("config/carpetfgaaddition/dropped-item-stack-limit.json");
+                boolean restarted = Files.exists(config);
+                check(FGASettings.droppedItemStackLimit.equals("false"), "default/persisted-off rule");
+                check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 64, "off inventory");
+                check(DroppedItemStackLimitConfig.effectiveContainerLimit(stone) == 64, "off container");
+                if (restarted) {
+                    check(DroppedItemStackLimitConfig.snapshot().inventoryLimit() == 1000
+                            && DroppedItemStackLimitConfig.snapshot().containerLimit() == 1000, "restart retains scopes");
+                }
+                FGASettings.droppedItemStackLimit = "true";
+                DroppedItemStackLimitConfig.setInventoryLimit(1000);
+                DroppedItemStackLimitConfig.setContainerLimit(1000);
+                byte[] saved = Files.readAllBytes(config);
+                check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 1000, "on inventory");
+                check(new SimpleContainer(1).getMaxStackSize(stone) == 1000, "on container consumer");
+                FGASettings.droppedItemStackLimit = "false";
+                check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 64, "toggle inventory");
+                SimpleContainer container = new SimpleContainer(1);
+                check(container.getMaxStackSize(stone) == 64, "toggle container");
+                check(new Slot(container, 0, 0, 0).getMaxStackSize(stone) == 64, "toggle slot");
+                DroppedItemStackLimitConfig.load(server);
+                check(DroppedItemStackLimitConfig.effectiveContainerLimit(stone) == 64, "reload while off");
+                check(Arrays.equals(saved, Files.readAllBytes(config)), "off/reload preserve file bytes");
+                FGASettings.droppedItemStackLimit = "true";
+                check(DroppedItemStackLimitConfig.effectiveInventoryLimit(stone) == 1000, "reenable retained scope");
+                check(DroppedItemStackLimitConfig.effectiveInventoryLimit(new ItemStack(Items.DIAMOND_SWORD)) == 1,
+                        "unstackable stays unstackable");
+                FGASettings.droppedItemStackLimit = "false";
+                System.out.println("FGA_SCOPED_COMPAT_PASS checks=" + checks + " restarted=" + restarted);
+            } catch (Throwable failure) {
+                System.out.println("FGA_SCOPED_COMPAT_FAIL " + failure);
+                failure.printStackTrace();
+            } finally {
+                server.halt(false);
+            }
+        });
+    }
+    private static void check(boolean condition, String name) {
+        if (!condition) throw new AssertionError(name);
+        checks++;
+    }
+}

--- a/scripts/tests/scoped-compat/resources/fabric.mod.json
+++ b/scripts/tests/scoped-compat/resources/fabric.mod.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "id": "fga_scoped_compat_test",
+  "version": "1.0.0",
+  "environment": "server",
+  "entrypoints": { "main": ["fga.scopedtest.ScopedCompatTest"] }
+}

--- a/src/main/java/carpet/fga/DroppedItemStackLimitConfig.java
+++ b/src/main/java/carpet/fga/DroppedItemStackLimitConfig.java
@@ -171,6 +171,11 @@ public final class DroppedItemStackLimitConfig {
 
     private static int scopedLimit(int configured, ItemStack stack) {
         int vanilla = stack.getMaxStackSize();
+        //#if MC == 1.21.1 || MC == 26.2
+        if (!FGASettings.isDroppedItemStackLimitEnabled() || loadFailed) {
+            return vanilla;
+        }
+        //#endif
         return configured > 0 && vanilla > 1 ? Math.max(vanilla, configured) : vanilla;
     }
 


### PR DESCRIPTION
On Minecraft 1.21.1 and 26.2, retained inventoryLimit/containerLimit values no longer expand effective limits when droppedItemStackLimit is disabled. Gate the shared scoped-limit resolver, including failed-load state. Preserve saved values, file format, atomic save behavior, defaults and permissions.

This is independent of the client-requirement fix (#15) and the Inventory inheritance fix. Other seven build nodes retain their existing scoped behavior for the deferred port. Update bilingual rules/commands and document the existing scoped set/reset syntax.

Validation:
- :1.21.1:build (Java 21) and :26.2:build (Java 25) passed, with separate artifact archives.
- Opt-in dedicated-server scoped-compat tests passed on both targets, including a second process using the same disposable world: retained scopes stay ineffective after restart, re-enable restores them, and configuration bytes are preserved.
- Runtime checks cover Container/Slot consumers, client-requirement predicates and deliberate damaged-config load/save refusal. The damaged file is only a disposable test fixture and is restored.
- git diff --check passed.

No real network-client login is asserted by this suite. Synthetic item maxima above 99 still need the separate Inventory fallback PR. Squash merge only.
