### PR TITLE
fix: preserve ItemEntity rule-off compatibility on 1.21.1 and 26.2

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -74,6 +74,8 @@
 
 在 Minecraft `1.21.1` 和 `26.2`，关闭 `droppedItemStackLimit` 会停止应用 `inventoryLimit` 和 `containerLimit`，包括重新加载配置与服务器重启之后。保存的非零值不会被删除，重新开启规则后恢复生效。
 
+在 Minecraft `1.21.1` 和 `26.2`，关闭 `droppedItemStackLimit` 时保留原合并数量参数和合并资格；FGA 不会重演合并资格来覆盖其他 Mod 的否决。`droppedItemMergeDistance=-1` 时保留传入的搜索范围，该距离规则独立于堆叠主规则。
+
 ## 深板岩切石与玩家加载距离
 
 | 规则 | 类型 | 默认值 | 可选值 | 生效版本 | 说明 |

--- a/docs/rules_en.md
+++ b/docs/rules_en.md
@@ -74,6 +74,8 @@ On Minecraft `1.21.1` and `26.2`, disabling `droppedItemStackLimit` preserves th
 
 On Minecraft `1.21.1` and `26.2`, disabling `droppedItemStackLimit` disables the effective `inventoryLimit` and `containerLimit`, including after configuration reload and server restart. Saved nonzero values are retained and take effect again when the rule is re-enabled.
 
+On Minecraft `1.21.1` and `26.2`, disabling `droppedItemStackLimit` preserves the original merge count arguments and eligibility; FGA does not replay eligibility to override another mod's veto. With `droppedItemMergeDistance=-1`, the supplied search box is preserved. The distance rule remains independent of the stack rule.
+
 ## Deepslate stonecutting and player loading
 
 | Rule | Type | Default | Values | Effective versions | Description |

--- a/scripts/tests/item-compat.gradle
+++ b/scripts/tests/item-compat.gradle
@@ -1,0 +1,27 @@
+// Opt-in test mod: never included in the distributable main jar.
+gradle.afterProject { p ->
+    // The preprocessor links source sets through every intermediate graph node.
+    if (p != p.rootProject) {
+        def smoke = p.sourceSets.create('itemCompat')
+        if (p.name == '1.21.1') {
+            smoke.java.srcDir p.rootProject.file('scripts/tests/item-compat/java')
+            smoke.resources.srcDir p.rootProject.file('scripts/tests/item-compat/resources')
+        }
+        smoke.compileClasspath += p.sourceSets.main.compileClasspath + p.sourceSets.main.output
+        smoke.runtimeClasspath += p.sourceSets.main.runtimeClasspath
+        p.tasks.named(smoke.compileJavaTaskName) {
+            setSource(p.rootProject.fileTree('scripts/tests/item-compat/java') { include '**/*.java' })
+        }
+        p.tasks.named(smoke.processResourcesTaskName) {
+            def priority = p.findProperty('compatPriority') ?: '1100'
+            inputs.property('compatPriority', priority)
+            filesMatching('*.mixins.json') {
+                filter { line -> line.replace('"priority": 1100', '"priority": ' + priority) }
+            }
+        }
+        p.loom.mods.create('fga_item_compat_test') { sourceSet smoke }
+        p.loom.runs.named('server') { source smoke }
+        p.tasks.named('runServer') { dependsOn p.tasks.named(smoke.classesTaskName) }
+    }
+}
+

--- a/scripts/tests/item-compat.md
+++ b/scripts/tests/item-compat.md
@@ -1,0 +1,25 @@
+# ItemEntity rule-off compatibility regression
+
+Build 1.21.1 with Java 21 and 26.2 with Java 25. Run the opt-in dedicated-server test
+mod for each version and both synthetic mixin priorities:
+
+```powershell
+python scripts/tests/run-rule-compat.py --version 1.21.1 --suite item-compat
+python scripts/tests/run-rule-compat.py --version 1.21.1 --suite item-compat --priority 900
+python scripts/tests/run-rule-compat.py --version 26.2 --suite item-compat
+python scripts/tests/run-rule-compat.py --version 26.2 --suite item-compat --priority 900
+```
+
+The default priority is 1100. Synthetic mixins veto eligibility, change expression
+capacities, replace the caller's merge-count argument, and supply a distinctive AABB.
+Tests execute the transformed Minecraft methods, asserting that disabled FGA retains
+those values, including the exact supplied AABB object. They also check active large
+stack merging, whitelist exclusion and the independent merge-distance rule.
+
+The query observer returns no neighbours so its inspection cannot modify a world.
+The runner creates disposable worlds and requires an explicit PASS marker. Existing
+Carpet mixins are loaded during these tests. No synthetic classes enter the main jar.
+
+The persistence hooks are intentionally unchanged. Oversized saved-item lifecycle
+and arbitrary third-party combinations still need separate gameplay tests. Only
+1.21.1 and 26.2 receive the new behavior; other preprocessor nodes retain old code.

--- a/scripts/tests/item-compat/java/fga/itemtest/ItemCompatTest.java
+++ b/scripts/tests/item-compat/java/fga/itemtest/ItemCompatTest.java
@@ -1,0 +1,83 @@
+package fga.itemtest;
+
+import carpet.fga.DroppedItemStackLimitConfig;
+import carpet.fga.FGASettings;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.phys.AABB;
+import java.lang.reflect.Method;
+
+public class ItemCompatTest implements ModInitializer {
+    public static boolean veto;
+    public static int cap, argument;
+    public static AABB customBox, seenBox;
+    private static int checks;
+
+    public void onInitialize() {
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            try {
+                Method eligible = ItemEntity.class.getDeclaredMethod("isMergable");
+                eligible.setAccessible(true);
+                Method neighbours = ItemEntity.class.getDeclaredMethod("mergeWithNeighbours");
+                neighbours.setAccessible(true);
+                Method merge = ItemEntity.class.getDeclaredMethod("merge", ItemEntity.class, ItemStack.class, ItemStack.class);
+                merge.setAccessible(true);
+                ItemEntity entity = new ItemEntity(server.overworld(), 0, 100, 0, new ItemStack(Items.STONE, 2));
+                for (String rule : new String[]{"false", "true"}) {
+                    FGASettings.droppedItemStackLimit = rule;
+                    DroppedItemStackLimitConfig.setAllMode(1000);
+                    veto = true;
+                    check(!(boolean) eligible.invoke(entity), "preserve veto " + rule);
+                    veto = false;
+                }
+                FGASettings.droppedItemStackLimit = "false";
+                cap = 13;
+                entity.setItem(new ItemStack(Items.STONE, 14));
+                check(!(boolean) eligible.invoke(entity), "preserve modified capacity");
+                check(!ItemEntity.areMergable(new ItemStack(Items.STONE, 7), new ItemStack(Items.STONE, 7)), "total cap");
+                ItemStack merged = ItemEntity.merge(new ItemStack(Items.STONE, 1), new ItemStack(Items.STONE, 20), 1000);
+                check(merged.getCount() == 13, "inner merge cap");
+                argument = 7;
+                merge.invoke(null, entity, new ItemStack(Items.STONE, 1), new ItemStack(Items.STONE, 10));
+                check(entity.getItem().getCount() == 7, "preserve passed merge argument");
+                FGASettings.droppedItemMergeDistance = -1;
+                customBox = new AABB(-3, 40, -7, 9, 50, 11);
+                neighbours.invoke(entity);
+                check(seenBox == customBox, "pass exact other-mod box");
+                customBox = null;
+                FGASettings.droppedItemMergeDistance = 2;
+                neighbours.invoke(entity);
+                AABB expected = entity.getBoundingBox().inflate(2, 0, 2);
+                check(seenBox.equals(expected), "distance rule works independently of stack rule");
+                FGASettings.droppedItemMergeDistance = -1;
+                cap = 0;
+                argument = 0;
+                FGASettings.droppedItemStackLimit = "true";
+                entity.setItem(new ItemStack(Items.STONE, 200));
+                check((boolean) eligible.invoke(entity), "active oversized eligibility");
+                check(ItemEntity.areMergable(new ItemStack(Items.STONE, 200), new ItemStack(Items.STONE, 200)), "active total");
+                merge.invoke(null, entity, new ItemStack(Items.STONE, 200), new ItemStack(Items.STONE, 200));
+                check(entity.getItem().getCount() == 400, "active entity merge");
+                DroppedItemStackLimitConfig.setWhitelistMode();
+                cap = 13;
+                entity.setItem(new ItemStack(Items.STONE, 14));
+                check(!(boolean) eligible.invoke(entity), "unconfigured item preserves other-mod cap");
+                System.out.println("FGA_ITEM_COMPAT_PASS checks=" + checks);
+            } catch (Throwable failure) {
+                System.out.println("FGA_ITEM_COMPAT_FAIL " + failure);
+                failure.printStackTrace();
+            } finally {
+                FGASettings.droppedItemStackLimit = "false";
+                FGASettings.droppedItemMergeDistance = -1;
+                server.halt(false);
+            }
+        });
+    }
+    private static void check(boolean condition, String name) {
+        if (!condition) throw new AssertionError(name);
+        checks++;
+    }
+}

--- a/scripts/tests/item-compat/java/fga/itemtest/mixin/ItemCompatMixin.java
+++ b/scripts/tests/item-compat/java/fga/itemtest/mixin/ItemCompatMixin.java
@@ -1,0 +1,58 @@
+package fga.itemtest.mixin;
+
+import fga.itemtest.ItemCompatTest;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import java.util.List;
+import java.util.function.Predicate;
+
+@Mixin(value = ItemEntity.class)
+public class ItemCompatMixin {
+    @Inject(method = "isMergable", at = @At("RETURN"), cancellable = true)
+    private void veto(CallbackInfoReturnable<Boolean> result) {
+        if (ItemCompatTest.veto) result.setReturnValue(false);
+    }
+
+    @ModifyExpressionValue(method = "isMergable",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I"))
+    private int eligibilityCap(int original) {
+        return ItemCompatTest.cap > 0 ? ItemCompatTest.cap : original;
+    }
+
+    @ModifyExpressionValue(method = {"areMergable",
+            "merge(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;I)Lnet/minecraft/world/item/ItemStack;"},
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I"))
+    private static int cap(int original) {
+        return ItemCompatTest.cap > 0 ? ItemCompatTest.cap : original;
+    }
+
+    @ModifyArg(method = "merge(Lnet/minecraft/world/entity/item/ItemEntity;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)V",
+            index = 2, at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/item/ItemEntity;merge(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;I)Lnet/minecraft/world/item/ItemStack;"))
+    private static int argument(int original) {
+        return ItemCompatTest.argument > 0 ? ItemCompatTest.argument : original;
+    }
+
+    @ModifyArg(method = "mergeWithNeighbours", index = 1,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getEntitiesOfClass(Ljava/lang/Class;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"))
+    private AABB customBox(AABB original) {
+        return ItemCompatTest.customBox != null ? ItemCompatTest.customBox : original;
+    }
+
+    @WrapOperation(method = "mergeWithNeighbours",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getEntitiesOfClass(Ljava/lang/Class;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"))
+    private List<ItemEntity> observeBox(Level level, Class<ItemEntity> type, AABB box,
+            Predicate<? super ItemEntity> predicate, Operation<List<ItemEntity>> original) {
+        ItemCompatTest.seenBox = box;
+        return List.of();
+    }
+}

--- a/scripts/tests/item-compat/resources/fabric.mod.json
+++ b/scripts/tests/item-compat/resources/fabric.mod.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "id": "fga_item_compat_test",
+  "version": "1.0.0",
+  "environment": "server",
+  "entrypoints": { "main": ["fga.itemtest.ItemCompatTest"] },
+  "mixins": ["item-compat.mixins.json"]
+}

--- a/scripts/tests/item-compat/resources/item-compat.mixins.json
+++ b/scripts/tests/item-compat/resources/item-compat.mixins.json
@@ -1,0 +1,8 @@
+{
+  "required": true,
+  "priority": 1100,
+  "package": "fga.itemtest.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": ["ItemCompatMixin"],
+  "injectors": { "defaultRequire": 1 }
+}

--- a/src/main/java/carpet/fga/mixin/ItemEntityMixin.java
+++ b/src/main/java/carpet/fga/mixin/ItemEntityMixin.java
@@ -4,6 +4,10 @@ package carpet.fga.mixin;
 import carpet.fga.DroppedItemStackLimitConfig;
 
 import carpet.fga.FGASettings;
+//#if MC == 1.21.1 || MC == 26.2
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+//#endif
 //#if MC >= 1.20.5 && MC < 1.21.5
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
@@ -43,47 +47,75 @@ public abstract class ItemEntityMixin {
     private static final String EXTENDED_COUNT_KEY = "carpet-fga-addition:ExtendedCount";
     private static final int VANILLA_SAVED_COUNT_LIMIT = 99;
 
-        // Avoid @Redirect on isMergable: Carpet also redirects getMaxStackSize there and hard-fails on conflict.
-    @Shadow
-    private int age;
-    @Shadow
-    private int pickupDelay;
-
-    @Inject(method = "isMergable", at = @At("RETURN"), cancellable = true)
-    private void carpetFga$stackLimitForMergable(CallbackInfoReturnable<Boolean> cir) {
-        ItemEntity self = (ItemEntity) (Object) this;
-        ItemStack stack = self.getItem();
-        int limit = FGASettings.effectiveDroppedItemStackLimit(stack);
-        if (cir.getReturnValueZ()) {
-            if (stack.getCount() >= limit) {
-                cir.setReturnValue(false);
-            }
-            return;
-        }
-        if (self.isAlive()
-                && pickupDelay != 32767
-                && age != -32768
-                && age < 6000
-                && stack.getCount() < limit) {
-            cir.setReturnValue(true);
-        }
+    //#if MC == 1.21.1 || MC == 26.2
+    @ModifyExpressionValue(method = "isMergable",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I"))
+    private int carpetFga$mergableCapacity(int original) {
+        return carpetFga$activeCapacity(original, ((ItemEntity) (Object) this).getItem());
     }
 
-    @Redirect(
-            method = "areMergable",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I")
-    )
-    private static int carpetFga$stackLimitForTotal(ItemStack stack) {
-        return FGASettings.effectiveDroppedItemStackLimit(stack);
+    @ModifyExpressionValue(method = "areMergable",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I"))
+    private static int carpetFga$totalCapacity(int original, ItemStack first, ItemStack second) {
+        return carpetFga$activeCapacity(original, second);
     }
 
-    @Redirect(
+    @ModifyExpressionValue(
             method = "merge(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;I)Lnet/minecraft/world/item/ItemStack;",
-            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I")
-    )
-    private static int carpetFga$stackLimitForMerge(ItemStack stack) {
-        return FGASettings.effectiveDroppedItemStackLimit(stack);
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I"))
+    private static int carpetFga$mergeCapacity(int original, ItemStack destination) {
+        return carpetFga$activeCapacity(original, destination);
     }
+
+    private static int carpetFga$activeCapacity(int original, ItemStack stack) {
+        if (!FGASettings.isDroppedItemStackLimitEnabled()) return original;
+        int configured = FGASettings.effectiveDroppedItemStackLimit(stack);
+        return configured != stack.getMaxStackSize() ? configured : original;
+    }
+    //#else
+//$$         // Avoid @Redirect on isMergable: Carpet also redirects getMaxStackSize there and hard-fails on conflict.
+//$$     @Shadow
+//$$     private int age;
+//$$     @Shadow
+//$$     private int pickupDelay;
+
+//$$     @Inject(method = "isMergable", at = @At("RETURN"), cancellable = true)
+//$$     private void carpetFga$stackLimitForMergable(CallbackInfoReturnable<Boolean> cir) {
+//$$         ItemEntity self = (ItemEntity) (Object) this;
+//$$         ItemStack stack = self.getItem();
+//$$         int limit = FGASettings.effectiveDroppedItemStackLimit(stack);
+//$$         if (cir.getReturnValueZ()) {
+//$$             if (stack.getCount() >= limit) {
+//$$                 cir.setReturnValue(false);
+//$$             }
+//$$             return;
+//$$         }
+//$$         if (self.isAlive()
+//$$                 && pickupDelay != 32767
+//$$                 && age != -32768
+//$$                 && age < 6000
+//$$                 && stack.getCount() < limit) {
+//$$             cir.setReturnValue(true);
+//$$         }
+//$$     }
+
+//$$     @Redirect(
+//$$             method = "areMergable",
+//$$             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I")
+//$$     )
+//$$     private static int carpetFga$stackLimitForTotal(ItemStack stack) {
+//$$         return FGASettings.effectiveDroppedItemStackLimit(stack);
+//$$     }
+
+//$$     @Redirect(
+//$$             method = "merge(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;I)Lnet/minecraft/world/item/ItemStack;",
+//$$             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;getMaxStackSize()I")
+//$$     )
+//$$     private static int carpetFga$stackLimitForMerge(ItemStack stack) {
+//$$         return FGASettings.effectiveDroppedItemStackLimit(stack);
+//$$     }
+
+    //#endif
 
     @ModifyArgs(
             method = "merge(Lnet/minecraft/world/entity/item/ItemEntity;Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)V",
@@ -94,7 +126,13 @@ public abstract class ItemEntityMixin {
     )
     private static void carpetFga$stackLimitForEntityMerge(Args args) {
         ItemStack destination = args.get(0);
-        args.set(2, FGASettings.effectiveDroppedItemStackLimit(destination));
+        //#if MC == 1.21.1 || MC == 26.2
+        if (!FGASettings.isDroppedItemStackLimitEnabled()) return;
+        int configured = FGASettings.effectiveDroppedItemStackLimit(destination);
+        if (configured != destination.getMaxStackSize()) args.set(2, configured);
+        //#else
+        //$$ args.set(2, FGASettings.effectiveDroppedItemStackLimit(destination));
+        //#endif
     }
 
     //#if MC >= 1.20.5 && MC < 1.21.6
@@ -215,21 +253,32 @@ public abstract class ItemEntityMixin {
     //$$ }
     //#endif
 
-    @Redirect(
-            method = "mergeWithNeighbours",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/world/level/Level;getEntitiesOfClass(Ljava/lang/Class;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"
-            )
-    )
-    private List<ItemEntity> carpetFga$mergeDistance(
-            Level level, Class<ItemEntity> entityClass, AABB vanillaBox,
-            Predicate<? super ItemEntity> predicate
-    ) {
-        Entity self = (Entity) (Object) this;
-        double distance = FGASettings.effectiveDroppedItemMergeDistance();
-        AABB box = self.getBoundingBox().inflate(distance, 0.0D, distance);
-        return level.getEntitiesOfClass(entityClass, box, predicate);
+    //#if MC == 1.21.1 || MC == 26.2
+    @ModifyArg(method = "mergeWithNeighbours", index = 1,
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getEntitiesOfClass(Ljava/lang/Class;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"))
+    private AABB carpetFga$mergeDistance(AABB original) {
+        if (FGASettings.droppedItemMergeDistance == -1.0D) return original;
+        // Adjust the supplied search box, preserving other mods' offsets and vertical bounds.
+        double delta = FGASettings.effectiveDroppedItemMergeDistance() - 0.5D;
+        return original.inflate(delta, 0.0D, delta);
     }
+    //#else
+//$$     @Redirect(
+//$$             method = "mergeWithNeighbours",
+//$$             at = @At(
+//$$                     value = "INVOKE",
+//$$                     target = "Lnet/minecraft/world/level/Level;getEntitiesOfClass(Ljava/lang/Class;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"
+//$$             )
+//$$     )
+//$$     private List<ItemEntity> carpetFga$mergeDistance(
+//$$             Level level, Class<ItemEntity> entityClass, AABB vanillaBox,
+//$$             Predicate<? super ItemEntity> predicate
+//$$     ) {
+//$$         Entity self = (Entity) (Object) this;
+//$$         double distance = FGASettings.effectiveDroppedItemMergeDistance();
+//$$         AABB box = self.getBoundingBox().inflate(distance, 0.0D, distance);
+//$$         return level.getEntitiesOfClass(entityClass, box, predicate);
+//$$     }
+    //#endif
 }
 //#endif


### PR DESCRIPTION
On Minecraft 1.21.1 and 26.2, disabled droppedItemStackLimit now preserves original merge capacities and caller-supplied count arguments. Replace the isMergable boolean replay and capacity Redirects with expression-value modifiers so other mods can still veto merging. The default merge-distance rule preserves the exact supplied AABB; active distance adjusts that box without reconstructing it from the entity.

Item persistence hooks remain unchanged. The other seven build nodes retain their prior implementation pending the separately requested port. Bilingual rule documentation and an opt-in synthetic compatibility suite are included.

Validation:
- :1.21.1:build (Java 21) and :26.2:build (Java 25) passed; artifacts archived separately.
- Actual dedicated-server item-compat tests passed 12 assertions on each target with synthetic priority 1100: veto, capacity override, count argument, AABB identity, independent distance rule, active oversized merging and whitelist exclusion.
- The priority 900 repetitions also passed 12 assertions on each target (four runtime runs in total).
- git diff --check passed.

Tests include the existing Carpet mixins. They do not certify arbitrary modpacks or oversized saved-item lifecycle behavior. No protocol, configuration-format, permission or rule-default change. Squash merge only.
